### PR TITLE
Support baseUrl option

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,11 @@ RequireJsFilter.prototype.transform = function (srcDir, destDir) {
   var options = this.options;
   var requirejs_options = options.requirejs || {};
 
-  requirejs_options.baseUrl = srcDir;
+  if (requirejs_options.baseUrl) {
+    requirejs_options.baseUrl = path.join(srcDir, requirejs_options.baseUrl);
+  } else {
+    requirejs_options.baseUrl = srcDir;
+  }
 
   return new RSVP.Promise(function(resolve, reject) {
     var tmp_options = _.clone(requirejs_options);


### PR DESCRIPTION
This allows you to set a `baseUrl` relative to your `srcDir`, instead of it just getting totally clobbered :)
