### PR TITLE
Depend on broccoli 0.7.0 to avoid being detected as affected by the hardlink issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "requirejs": "~2.1.11",
     "mkdirp": "~0.3.5",
     "rsvp": "~3.0.6",
-    "broccoli": "~0.3.0",
+    "broccoli": "~0.7.0",
     "lodash": "~2.4.1"
   }
 }


### PR DESCRIPTION
The hardlink issue is being described here: https://github.com/joliss/broccoli/blob/master/docs/hardlink-issue.md

While `broccoli-requirejs` seems unaffected, the detection will suggest otherwise as this is depending on broccoli 0.3.0. Bump the version to at least 0.7.0
